### PR TITLE
Add nvcc options

### DIFF
--- a/ext/llama_cpp/extconf.rb
+++ b/ext/llama_cpp/extconf.rb
@@ -112,7 +112,7 @@ create_makefile('llama_cpp/llama_cpp')
 if with_config('cublas')
   File.open('Makefile', 'a') do |f|
     f.puts 'ggml-cuda.o: ggml-cuda.cu ggml-cuda.h'
-    f.puts "\tnvcc -arch=native -c -o $@ $<"
+    f.puts "\tnvcc -shared -Xcompiler -fPIC -arch=native -c -o $@ $<"
   end
 end
 


### PR DESCRIPTION
This PR is to avoid following errors during installation with cuBLAS:

```
linking shared-object llama_cpp/llama_cpp.so
/usr/bin/ld: ggml-cuda.o: relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make: *** [Makefile:265: llama_cpp.so] Error 1
```

According to this article https://forums.developer.nvidia.com/t/shared-library-creation/4776/10 this seems to be needed when building `.so`.

verification environment:
- Ubuntu 20.04
- nvcc V12.2.140
- NVIDIA RTX 3060
