### PR TITLE
Set encoding to avoid Encoding::CompatibilityError

### DIFF
--- a/lib/llama_cpp.rb
+++ b/lib/llama_cpp.rb
@@ -104,7 +104,7 @@ module LLaMACpp
       break if !embd.empty? && embd[-1] == context.token_eos
     end
 
-    output.join.delete_prefix(spaced_prompt).strip
+    output.join.force_encoding('UTF-8').delete_prefix(spaced_prompt).strip
   end
 end
 


### PR DESCRIPTION
This PR is to avoid following error on `LLaMACpp.generate`.

```
/home/keyasuda/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/llama_cpp-0.5.1/lib/llama_cpp.rb:107:in `delete_prefix': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
	from /home/keyasuda/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/llama_cpp-0.5.1/lib/llama_cpp.rb:107:in `generate'
	from test2.rb:8:in `<main>'
```

Test script is like following:
```
require 'llama_cpp'

params = LLaMACpp::ContextParams.new
params.seed = 42
model = LLaMACpp::Model.new(model_path: ARGV[0], params: params)
context = LLaMACpp::Context.new(model: model)
prompt = '[INST] <<SYS>>あなたは誠実で優秀な日本人のアシスタントです。<</SYS>>明日の天気は?[/INST]'
puts LLaMACpp.generate(context, prompt, n_threads: 16, n_predict: 256)
```
